### PR TITLE
Fix return type errors

### DIFF
--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -112,4 +112,14 @@ class FieldDescription extends BaseFieldDescription
 
         return $this->getFieldValue($object, $this->fieldName);
     }
+
+    public function getType(): ?string
+    {
+        return $this->type ? (string)$this->type : null;
+    }
+
+    public function getHelp(): string
+    {
+        return $this->help ?? '';
+    }
 }


### PR DESCRIPTION
Fix voor:

- Return value of Sonata\AdminBundle\Admin\BaseFieldDescription::getHelp() must be of the type string, null returned
- Return value of Sonata\AdminBundle\Admin\BaseFieldDescription::getType() must be of the type string or null, int returned